### PR TITLE
Update rebar.config to use Hex dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ rel/example_project
 .erlang.mk*
 elvis
 *.d
+/_build
+/rebar.lock

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-
+%%% -*- mode: erlang; -*-
 {erl_opts,
  [
   {src_dirs, ["src"]}
@@ -8,10 +8,21 @@
 {deps_dir, "deps"}.
 {deps,
  [
-  {cowboy,  ".*", {git, "https://github.com/ninenines/cowboy.git", "1.0.4"}},
-  {ranch,   ".*", {git, "https://github.com/ninenines/ranch.git",  "1.2.1"}}
+  {cowboy,  "1.0.4"},
+  {ranch,   "1.2.1"}
  ]
 }.
+
+{profiles, [
+            {test, [
+                    {deps, [
+                            {katana_test, {git, "https://github.com/inaka/katana-test", {ref, "0.0.5"}}},
+                            {mixer, {git, "https://github.com/inaka/mixer", {ref, "0.1.5"}}},
+                            {meck, "0.8.4"},
+                            {xref_runner, {git, "https://github.com/inaka/xref_runner", {ref, "0.2.6"}}}
+                           ]}
+                   ]}
+           ]}.
 
 {xref_warnings, true}.
 {xref_checks,

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,33 @@
+%% -*- mode: erlang; -*-
+case erlang:function_exported(rebar3, main, 1) of
+    true ->
+        %% rebar3
+        CONFIG;
+    false ->
+        %% rebar 2.x or older
+        %% rebuild deps
+        Rebar3Deps = proplists:get_value(deps, CONFIG),
+        Rebar3TestDeps =
+        proplists:get_value(deps,
+                            proplists:get_value(test,
+                                                proplists:get_value(profiles,
+                                                                    CONFIG))),
+
+        %% whenever adding a new Hex package dependency, this fun should be
+        %% updated
+        HexToRepo = fun(cowboy) -> "https://github.com/ninenines/cowboy.git";
+                       (ranch) -> "https://github.com/ninenines/ranch.git";
+                       (meck) -> "https://github.com/eproxus/meck.git"
+                    end,
+
+        ConvertDep =
+        fun({DepName, {git, Repo, {ref, Tag}}}) ->
+            {DepName, ".*", {git, Repo, {tag, Tag}}};
+           ({HexDepName, HexDepVersion}) ->
+            {HexDepName, ".*", {git, HexToRepo(HexDepName), {tag, HexDepVersion}}}
+        end,
+
+        Rebar2Deps = [ ConvertDep(Dep) || Dep <- Rebar3Deps ++ Rebar3TestDeps ],
+
+        lists:keystore(deps, 1, CONFIG, {deps, Rebar2Deps})
+end.


### PR DESCRIPTION
The current Hex package for `trails` is broken because it includes a (test) dependency on `katana` 0.2.18, which doesn't exist.

I'm not sure what the correct way is to get Erlang.mk to skip test dependencies when packaging, but this should do the trick for Rebar.
