### PR TITLE
[#82] Don't call ensure_all_started from do_store

### DIFF
--- a/src/trails.erl
+++ b/src/trails.erl
@@ -283,7 +283,6 @@ trails([Module | T], Acc) ->
                Trails::[route_path()]) -> ok.
 do_store(_Server, _HostMatch, []) -> ok;
 do_store(Server, HostMatch, [Trail = #{path_match := PathMatch} | Trails]) ->
-  {ok, _} = application:ensure_all_started(trails),
   ets:insert(trails, {{Server, HostMatch, PathMatch}, Trail}),
   do_store(Server, HostMatch, Trails).
 

--- a/test/trails_SUITE.erl
+++ b/test/trails_SUITE.erl
@@ -302,6 +302,7 @@ trails_store(_Config) ->
   ],
   {not_started, trails} = (catch trails:all()),
   {not_started, trails} = (catch trails:retrieve("/")),
+  {ok, _} = application:ensure_all_started(trails),
   ok = trails:store(TrailsRaw),
   Trails = normalize_paths(TrailsRaw),
   Length = length(Trails),
@@ -350,8 +351,6 @@ minimal_multiple_host_compile_test(_Config) ->
   Repeated1 = trails:retrieve("host1", "/repeated"),
   notfound = trails:retrieve("host2", "/path1"),
   notfound = trails:retrieve("unknown_host", "/path1"),
-  % Test that trails:do_store/3 actually starts trails application
-  ok = application:stop(trails),
   ok = trails:store([{"host3", Trails1}, {"host4", Trails2}]),
   {comment, ""}.
 


### PR DESCRIPTION
[Fixes #82]
Unfortunately with this change trails:store/1,2 can't be called anymore without
starting up trails earlier.