### PR TITLE
Fix 0.2.1 type -spec().s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.2.2](https://github.com/inaka/cowboy-trails/tree/0.2.2) (2019-02-18)
+[Full Changelog](https://github.com/inaka/cowboy-trails/compare/0.2.1...0.2.2)
+
+**Merged pull requests:**
+
+- Fix unknown type cowboy_route:route_match [\#89](https://github.com/inaka/cowboy-trails/pull/89) ([paulo-ferraz-oliveira](https://github.com/paulo-ferraz-oliveira))
+
 ## [0.2.1](https://github.com/inaka/cowboy-trails/tree/0.2.1) (2016-10-05)
 [Full Changelog](https://github.com/inaka/cowboy-trails/compare/0.2.0...0.2.1)
 

--- a/rebar.config
+++ b/rebar.config
@@ -37,3 +37,15 @@
   , deprecated_functions
   ]
 }.
+
+{dialyzer, 
+  [
+    {warnings,
+      [
+        underspecs
+      , unmatched_returns
+      , error_handling
+      , unknown
+    ]}
+  , {plt_extra_apps, [cowboy, ranch, cowlib]}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -8,8 +8,8 @@
 {deps_dir, "deps"}.
 {deps,
  [
-  {cowboy,  "1.0.4"},
-  {ranch,   "1.2.1"}
+  {cowboy,  "1.1.2"},
+  {ranch,   "1.3.2"}
  ]
 }.
 

--- a/src/trails.app.src
+++ b/src/trails.app.src
@@ -2,7 +2,7 @@
  [
   {description,
    "A couple of improvements over Cowboy Routes"},
-  {vsn, "0.2.1"},
+  {vsn, "0.2.2"},
   {applications,
     [kernel,
      stdlib

--- a/src/trails.erl
+++ b/src/trails.erl
@@ -23,7 +23,7 @@
 
 %% Trail specification
 -opaque trail() ::
-  #{ path_match  => cowboy_router:route_match()
+  #{ path_match  => route_match()
    , constraints => cowboy_router:constraints()
    , handler     => module()
    , options     => any()
@@ -119,7 +119,7 @@ trail(PathMatch, ModuleHandler, Options, MetaData, Constraints) ->
    }.
 
 %% @doc Gets the `path_match' from the given `trail'.
--spec path_match(trail()) -> cowboy_router:route_match().
+-spec path_match(trail()) -> route_match().
 path_match(Trail) ->
   maps:get(path_match, Trail, []).
 


### PR DESCRIPTION
The type-related changes proposed here have already been included in cowboy-trails 1.0.0, so there's also the possibility of improving that one and then using it on cowboy_swagger (as is the intent of this pull request).