### PR TITLE
Bump some dep.s for OTP 24 compatibility

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -11,11 +11,6 @@
         ruleset => erl_files
        },
       #{dirs => ["."],
-        filter => "Makefile",
-        rules => [{elvis_project, protocol_for_deps_erlang_mk, #{regex => "(https://.*|[0-9]+([.][0-9]+)*)"}}],
-        ruleset => makefiles
-       },
-      #{dirs => ["."],
         filter => "rebar.config",
         ruleset => rebar_config
        },

--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 
 {project_plugins,
  [
-  {rebar3_lint, "0.3.2"}
+  {rebar3_lint, "0.4.0"}
  ]
 }.
 

--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 
 {project_plugins,
  [
-  {rebar3_lint, "0.3.0"}
+  {rebar3_lint, "0.3.2"}
  ]
 }.
 
@@ -24,8 +24,8 @@
                     {cover_opts, [verbose]},
                     {deps, [
                             {katana_test, "1.0.1"},
-                            {mixer, "1.1.0", {pkg, inaka_mixer}},
-                            {meck, "0.9.0"},
+                            {mixer, "1.1.1", {pkg, inaka_mixer}},
+                            {meck, "0.9.2"},
                             {xref_runner, "1.2.0"}
                            ]}
                    ]}


### PR DESCRIPTION
- `rebar3_lint` brings improvements in linting
- `meck` drops `hamcrest` (one less dep. to deal with)
- `mixer` is up'ed for ~no practical reason~ compatibility with OTP 24 (as per pull request there)

Had this pending here from my OTP-24 tests.

- [x] wait for `elvis_core` (post 1.1.1) + `rebar3_lint` (post 0.3.2) to be released
- [x] ~~`ct`'s failing~~ (it was a local thing)